### PR TITLE
Make anybody be able to launch tests and a bugfix on two of the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,55 @@ major:
 
 
 .PHONY: patch minor major
+
+
+# run tests using docker
+pg_container	= pgxscan_postgres
+network_name	= pgxscan_network
+pg_user 		= root
+pg_pass			= pass
+pg_db			= pgxscan
+
+net-up:
+	docker network create $(network_name)
+
+net-down:
+	docker network rm $(network_name) || true
+
+ifneq ("$(EXPOSE)","")
+EXPOSE_PORTS=-p 5435:5432
+endif
+
+db-up:
+	docker run \
+		--rm \
+		-d \
+		--network $(network_name) \
+		--name $(pg_container) \
+		$(EXPOSE_PORTS) \
+		--env POSTGRES_USER=$(pg_user) \
+		--env POSTGRES_PASSWORD=$(pg_pass) \
+		--env POSTGRES_DB=$(pg_db) \
+		postgres:12-alpine
+
+db-down:
+	docker stop $(pg_container) || true
+
+test-up: | net-up db-up
+test-down: | db-down net-down
+
+test:
+	$(MAKE) test-down
+	$(MAKE) test-up
+	$(MAKE) test-go
+	$(MAKE) test-down
+
+test-go:
+	docker run \
+		--rm \
+		--network $(network_name) \
+		--volume `pwd`:/test-go/ \
+		--workdir /test-go \
+		--env PG_URI="postgres://$(pg_user):$(pg_pass)@$(pg_container):5432/$(pg_db)?sslmode=disable" \
+		-it golang:1.14-buster \
+		go test -v ./...

--- a/internal/test/schema.go
+++ b/internal/test/schema.go
@@ -5,9 +5,11 @@ import (
 )
 
 const schema = `
-        DROP TABLE IF EXISTS "test";
-        CREATE  TABLE "test" (
-            "id" SERIAL PRIMARY KEY NOT NULL,
+		DROP TABLE IF EXISTS "test";
+		DROP TABLE IF EXISTS "address";
+		DROP TABLE IF EXISTS "users";
+		CREATE TABLE "test" (
+			"id" SERIAL PRIMARY KEY NOT NULL,
 			"int" INT,
 			"int_8" SMALLINT,
 			"int_16" SMALLINT,
@@ -34,7 +36,31 @@ const schema = `
 			"json_b" jsonb,
 			"map" jsonb
 		);
-    `
+		CREATE TABLE "users" (
+			"id" SERIAL PRIMARY KEY NOT NULL,
+			"name" VARCHAR,
+			"email" VARCHAR
+		);
+		CREATE TABLE "address" (
+			"id" SERIAL PRIMARY KEY NOT NULL,
+			"user_id" INT NOT NULL,
+			"line_1" VARCHAR,
+			"city" VARCHAR,
+
+			CONSTRAINT fk_user_address FOREIGN KEY (user_id) REFERENCES users(id)
+		);
+
+		INSERT INTO "users" (id, name, email)
+		   VALUES (1, 'user01', 'user01@email.com'),
+		          (2, 'user02', 'user02@email.com'),
+		          (3, 'user03', 'user03@email.com')
+		;
+
+		INSERT INTO "address" (id, user_id, line_1, city)
+		   VALUES (1, 1, 'line01_user01', 'city01'),
+		          (2, 2, 'line02_user02', 'city02')
+		;
+	`
 
 var TestCols = []string{
 	"int",

--- a/rows_test.go
+++ b/rows_test.go
@@ -466,5 +466,15 @@ FROM
 	if err := NewScanner(rows).Scan(&user); err != nil {
 		rt.NoError(err)
 	}
-	fmt.Println(user)
+
+	rt.Equal(User{
+		ID:    1,
+		Name:  "user01",
+		Email: "user01@email.com",
+		Address: Address{
+			ID:    1,
+			Line1: "line01_user01",
+			City:  "city01",
+		},
+	}, user)
 }

--- a/scanner.go
+++ b/scanner.go
@@ -110,7 +110,7 @@ func validate(i interface{}) (reflect.Value, error) {
 		return reflect.Value{}, errors.New("destination must be initialized. Don't use var foo *Foo. Use foo := new(Foo) or foo := &Foo{}")
 	}
 
-	if val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Ptr {
 		if val.IsNil() {
 			v := reflect.New(val.Type().Elem())
 			// TODO: refactoring required to handle non initialized nil values like, `var foo *Foo`


### PR DESCRIPTION
I was exploring the idea of creating myself the functionality for this ticket: https://github.com/randallmlough/pgxscan/issues/5

And so I downloaded the code, but was unable to run the tests since I had to manually setup the database, and also found out a couple of tables for users and address were missing, so I thought to use the makefile to automate it so anybody can easily launch the tests without having to configure anything manually.

You can now run `make test` and it will create a postgres 12 database using docker and launch the tests with golang 1.14 (those values can be easily changed, or even parametrized). I also added a couple of missing tables and some test data.

You can also run `make test-up EXPOSE=1` to create a virtual network & empty postgres database which is exposed to your localhost at port 5435 (although it has a predefined user and a pass).

Not sure if you'll have some uncommited changes locally or any other local branch, but there were two failing tests, so after playing a little bit with the code I found a fix for it.

I hope it makes sense to merge to master. I have not incremented the version, though, since this only contains a fix it might be a good idea to increment it to 0.1.1... Let me know if you have any thoughts. 