### PR TITLE
Identify field name when a column value does not match struct type

### DIFF
--- a/.docker/testdata.sql
+++ b/.docker/testdata.sql
@@ -51,7 +51,8 @@ CREATE TABLE "public"."users" (
 INSERT INTO "public"."users" ("id", "name", "email") VALUES
 ('1', 'user01', 'user01@email.com'),
 ('2', 'user02', 'user02@email.com'),
-('3', 'user03', 'user03@email.com');
+('3', 'user03', 'user03@email.com'),
+('10', NULL, 'user03@email.com');
 
 
 DROP TABLE IF EXISTS "public"."address";

--- a/scanner.go
+++ b/scanner.go
@@ -6,6 +6,9 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/randallmlough/sqlmaper"
 	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -87,6 +90,21 @@ func ScanStruct(scan scannerFunc, i interface{}, cols []string) error {
 	}
 
 	if err := scan(scans...); err != nil {
+		// identify the offending field in case types do not match, very useful
+		// when using this library
+		if strings.HasPrefix(err.Error(), "can't scan into dest[") {
+			// TODO: use ScanArgError if made public (see https://github.com/jackc/pgx/issues/931)
+			//       to avoid all this parsing
+			splitted := strings.Split(err.Error(), ":")
+			re := regexp.MustCompile(`\[(\d+)\]`)
+			errCol, errConv := strconv.Atoi(
+				strings.Trim(string(re.Find([]byte(splitted[0]))), "[]"),
+			)
+			if errConv != nil {
+				return err
+			}
+			return fmt.Errorf("%s (field '%s'):%s", splitted[0], cols[errCol], splitted[1])
+		}
 		return err
 	}
 


### PR DESCRIPTION
Reworked branch. The other PR was closed because I sort of rewrote my history, apparently. Anyway, I'm copying the same comment as on PR8

I've created another minor improvement in order to display the field name when a column type (or value, eg. NULL) does not match the struct type.

Instead of errors like:

    can't scan into dest[1]: cannot assign NULL to *string
    can't scan into dest[2]: unable to assign to *int

We now get:

    can't scan into dest[1] (field 'name'): cannot assign NULL to *string
    can't scan into dest[2] (field 'email'): unable to assign to *int

Imagine it says dest[21]... it is error prone to count which column is it referring to.

I've added a couple of tests.

I've also created a new ticket on pgx library (and a pull request), so that we can avoid all the parsing that needs to be done now:
jackc/pgx#931

But meanwhile this does the trick.