### PR TITLE
Add benchmark to measure scan performance on different setups

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.15-alpine
 
+RUN apk add --update --no-cache alpine-sdk
+
 WORKDIR /pgxscan
 
 COPY go.mod .
@@ -8,6 +10,4 @@ COPY go.sum .
 RUN go mod download
 COPY . ./
 
-RUN apk add --update --no-cache alpine-sdk
-
-CMD go test -v -race --tags=integration ./...
+CMD go test -v -race -bench=. -benchmem --tags=integration ./...

--- a/pgxscan_integration_test.go
+++ b/pgxscan_integration_test.go
@@ -33,13 +33,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newTestDB(t *testing.T) *pgxpool.Conn {
+func newTestDB(tb testing.TB) *pgxpool.Conn {
 	conn, err := testDB.Acquire(ctxb)
 	if err != nil {
-		t.Fatalf("error aquiring a new connection: %v", err)
+		tb.Fatalf("error aquiring a new connection: %v", err)
 	}
 
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		conn.Release()
 	})
 


### PR DESCRIPTION
I just wanted to measure the preformance impact of the new feature (the new sql extra column...) and I thought it would be nice to have some sort of baseline to compare in case anytime anyone wants to improve performance of the library itself in terms of speed or less allocations. So I made 3 benchmarks, one with PGX library itself, to manually scan the fields, and then using the struct notation and the SQL notation column.

I know this benchmark is far from perfect, but it can be used to start improving upon. I'm kind of surprised on the results on my computer with a -benchtime of 20seconds:
```
Benchmark_rows_JoinPgxBaseline
Benchmark_rows_JoinPgxBaseline-8               	14113027	      1714 ns/op	     676 B/op	       6 allocs/op
Benchmark_rows_JoinTableWithStructNotation
Benchmark_rows_JoinTableWithStructNotation-8   	  285048	     87500 ns/op	    1797 B/op	      30 allocs/op
Benchmark_rows_JoinTableWithSqlNotation
Benchmark_rows_JoinTableWithSqlNotation-8      	  302793	     79965 ns/op	    2075 B/op	      41 allocs/op
```
PGX library performs the best, which was the expected, but for whatever reason I don't understand, the performance of the one with SQL notation is faster than the other... even though, in theory, it has to do more work... \_(O_o)_/

Anyway, I changed Dockerfile to include benchmarks and I've also moved the apk update line to the top of the file, because otherwise everytime a line single file is changed in the project it needs to redownload updates on the alpine docker image and it takes a lot of time. This way it is cached locally and make test works way faster.